### PR TITLE
Options symbols seem to need to be uppercase

### DIFF
--- a/lib/jekyll-commonmark.rb
+++ b/lib/jekyll-commonmark.rb
@@ -7,9 +7,9 @@ module Jekyll
       def initialize(config)
         Jekyll::External.require_with_graceful_fail "commonmarker"
         begin
-          @options = config['commonmark']['options'].collect { |e| e.to_sym }
+          @options = config['commonmark']['options'].collect { |e| e.upcase.to_sym }
         rescue NoMethodError
-          @options = [:default]
+          @options = [:DEFAULT]
         else
           @options.reject! do |e|
             unless CommonMarker::Config::Parse.keys.include? e.to_sym


### PR DESCRIPTION
Hi Pat,

I've been getting excited about CommonMark and trying to get it working nicely in Jekyll.

It seems like, from the code and the readme for [CommonMarker](https://github.com/gjtorikian/commonmarker), that options symbols need to be uppercase to be recognized.

If I don't upcase them, I get this:

```
Conversion error: Jekyll::Converters::Markdown encountered an error while converting 'hierarchy/example/plant/fruit/apple/ambrosia.md':
    option ':default' does not exist for CommonMarker::Config::Parse
```

I'm not great at Ruby but these changes seemed to resolve the problem for me.